### PR TITLE
update Pdfinfo::Page.from_string to handle strings without a rotation

### DIFF
--- a/lib/pdfinfo/page.rb
+++ b/lib/pdfinfo/page.rb
@@ -11,7 +11,7 @@ class Pdfinfo
       new *string.scan(MATCHER).flatten
     end
 
-    def initialize(width, height, rotation)
+    def initialize(width, height, rotation=0.0)
       @width       = width.to_f
       @height      = height.to_f
       @rotation    = rotation.to_f

--- a/spec/pdfinfo/page_spec.rb
+++ b/spec/pdfinfo/page_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Pdfinfo::Page do
       expect(Pdfinfo::Page).to receive(:new).with('595.28', '841.89', '20')
       subject
     end
+
+    it 'returns an instance of Pdfinfo::Page given a string that does not include a rotation' do
+      expect(described_class.from_string("595.28 x 841.89 pts (A4)")).to be_instance_of(Pdfinfo::Page)
+    end
   end
 
   describe '#height' do


### PR DESCRIPTION
Not all PDFs have a rotation in the `Page size: 612 x 792 pts (letter)` string. Added a default value for rotation in the `Pdfinfo::Page#initalize`.
